### PR TITLE
fix(datadragon): adjust usage of name and id when getting champion

### DIFF
--- a/datadragon/data_dragon_test.go
+++ b/datadragon/data_dragon_test.go
@@ -75,9 +75,9 @@ func TestClient_GetChampion(t *testing.T) {
 		{
 			name: "get response",
 			doer: dataDragonResponseDoer(map[string]ChampionDataExtended{
-				"champion": {},
+				"champion": {ChampionData: ChampionData{Name: "champion", ID: "champion"}},
 			}),
-			want: ChampionDataExtended{},
+			want: ChampionDataExtended{ChampionData: ChampionData{Name: "champion", ID: "champion"}},
 		},
 		{
 			name:    "not found",
@@ -350,11 +350,11 @@ func TestClient_GetChampionByID(t *testing.T) {
 	tests := []test{
 		{
 			name: "get response",
-			doer: dataDragonResponseDoer(map[string]ChampionData{
-				"champion": {Name: "champion", ID: "id"},
+			doer: dataDragonResponseDoer(map[string]ChampionDataExtended{
+				"champion": {ChampionData: ChampionData{Name: "champion", ID: "champion"}},
 			}),
-			id:   "id",
-			want: ChampionDataExtended{ChampionData: ChampionData{Name: "champion", ID: "id"}},
+			id:   "champion",
+			want: ChampionDataExtended{ChampionData: ChampionData{Name: "champion", ID: "champion"}},
 		},
 		{
 			name:    "not found",


### PR DESCRIPTION
>previously the name of the champion was used to request detailed data for the champion. The DataDragon API however accepts the ID of champion instead. In many cases there is no difference between the ID and the Name. Champions with spaces or other non-alphabetic characters in their name were unable to be retrieved using the GetChampion method. This commit refactors usage of identifier for champions from name to ID.

merging fix/get_champion with main, then gonna create another branch for me to experiment on